### PR TITLE
Adding a fix proposal for @return statement

### DIFF
--- a/src/MarkdownDocsProcessor.ts
+++ b/src/MarkdownDocsProcessor.ts
@@ -322,6 +322,10 @@ export default abstract class MarkdownDocsProcessor extends DocsProcessor {
           this.addParameters(generator, level, methodModel);
         }
 
+        if (methodModel.getReturns().length) {
+          this.addReturns(generator, level, methodModel);
+        }
+
         if (methodModel.getThrownExceptions().length) {
           this.addThrowsBlock(generator, level, methodModel);
         }
@@ -374,6 +378,19 @@ export default abstract class MarkdownDocsProcessor extends DocsProcessor {
 
     generator.addBlankLine();
   }
+
+  private addReturns(generator: MarkdownHelper, level: number, methodModel: MethodModel) {
+    generator.addTitle('Return', level + 3);
+    generator.addBlankLine();
+    generator.addText('**Type**');
+    generator.addBlankLine();
+    generator.addText(methodModel.getReturnType());
+    generator.addBlankLine();
+    generator.addText('**Description**');
+    generator.addBlankLine();
+    generator.addText(methodModel.getReturns());
+    generator.addBlankLine();
+}
 
   private addThrowsBlock(generator: MarkdownHelper, level: number, methodModel: MethodModel) {
     generator.addTitle('Throws', level + 3);


### PR DESCRIPTION
Hello Cesar,
I looked a bit at the Issue #9 which I opened earlier, and at the source for the plugin as well. I'm proposing a simple fix in MarkdownDocsProcessor to add the returns in the generator, using the string proposed by the parent ApexModel of the MethodModel.
In terms of format what I'm proposing is really basic, but if you have a better idea of course ... your project after all ! ^^
I tested this change on my docs and had the expected result.

Let me know if that's useful !
Nicolas