### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ files.
 
 `generate(sourceDirectory[,recursive][,scope][,outputDir])`
 
-- `sourceDirectory` \<string>
+- `sourceDirectory` \<string>[]
 - `recursive` \<boolean>
 - `scope` \<string[]>
 - `outpurDir` \<string>
@@ -180,7 +180,7 @@ files.
 ```javascript
 var { generate } = require('@cparra/apexdocs');
 
-let documentedClasses = generate('src', true, ['global'], 'docs');
+let documentedClasses = generate(['src'], true, ['global'], 'docs');
 ```
 
 ## Documentation Format


### PR DESCRIPTION
Updated 1x documentation to show that the generate() function's sourceDirectory argument is expected to be an array of strings rather than a single string. 