### PR TITLE
Fixes: https://github.com/cesarParra/apexdocs/issues/96

### DIFF
--- a/docs/types/Classes/nspc.ChildClass.md
+++ b/docs/types/Classes/nspc.ChildClass.md
@@ -56,7 +56,7 @@ This method was overridden.
 
 |Type|Description|
 |---|---|
-|String|A String.|
+|`String`|A String.|
 
 ### `public void execute()`
 
@@ -70,7 +70,7 @@ Returns a value based on the executed command.
 
 |Type|Description|
 |---|---|
-|String|The value|
+|`String`|The value|
 
 ### `public String overridableMethod()`
 

--- a/docs/types/Main/nspc.SampleClass.md
+++ b/docs/types/Main/nspc.SampleClass.md
@@ -114,7 +114,7 @@ Executes commands based on the passed in argument.
 
 |Type|Description|
 |---|---|
-|String|Empty string|
+|`String`|Empty string|
 
 ###### Example
 ```apex

--- a/docs/types/Misc-Group/nspc.InterfaceWithInheritance.md
+++ b/docs/types/Misc-Group/nspc.InterfaceWithInheritance.md
@@ -24,6 +24,6 @@ Returns a value based on the executed command.
 
 |Type|Description|
 |---|---|
-|String|The value|
+|`String`|The value|
 
 ---

--- a/docs/types/Misc-Group/nspc.SampleRestResource.md
+++ b/docs/types/Misc-Group/nspc.SampleRestResource.md
@@ -42,7 +42,7 @@ This is a sample HTTP Get method
 
 |Type|Description|
 |---|---|
-|Account|An Account SObject.|
+|`Account`|An Account SObject.|
 
 
 **Http Parameter** name: limit in: query required: true description: Limits the number of items on a page schema:   type: integer
@@ -75,7 +75,7 @@ This is a sample HTTP Post method
 
 |Type|Description|
 |---|---|
-|String|A String SObject.|
+|`String`|A String SObject.|
 
 
 **Summary** Posts an Account 2

--- a/docs/types/Misc-Group/nspc.SampleRestResourceWithInnerClass.md
+++ b/docs/types/Misc-Group/nspc.SampleRestResourceWithInnerClass.md
@@ -15,7 +15,7 @@ This is a sample HTTP Get method
 
 |Type|Description|
 |---|---|
-|InnerClass|A SampleRestResourceWithInnerClass.InnerClass Object.|
+|`InnerClass`|A SampleRestResourceWithInnerClass.InnerClass Object.|
 
 
 **Http Response** statusCode: 200 schema: SampleRestResourceWithInnerClass.InnerClass

--- a/docs/types/Sample-Interfaces/nspc.SampleInterface.md
+++ b/docs/types/Sample-Interfaces/nspc.SampleInterface.md
@@ -18,6 +18,6 @@ Returns a value based on the executed command.
 
 |Type|Description|
 |---|---|
-|String|The value|
+|`String`|The value|
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cparra/apexdocs",
-  "version": "2.17.1",
+  "version": "2.17.2",
   "description": "Library with CLI capabilities to generate documentation for Salesforce Apex classes.",
   "keywords": [
     "apex",

--- a/src/model/markdown-generation-util/method-declaration-util.ts
+++ b/src/model/markdown-generation-util/method-declaration-util.ts
@@ -123,7 +123,7 @@ function addReturns(
   markdownFile.addTitle('Returns', startingHeadingLevel + 3);
   markdownFile.initializeTable('Type', 'Description');
   markdownFile.addTableRow(
-    methodModel.typeReference.rawDeclaration,
+    `\`${methodModel.typeReference.rawDeclaration}\``,
     methodModel.docComment?.returnAnnotation.bodyLines.join(' '),
   );
   markdownFile.addBlankLine();


### PR DESCRIPTION
Apply code formatting to output parameter type documentation