### PR TITLE
Exclude

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,23 @@ export default defineMarkdownConfig({
 });
 ```
 
+### Excluding Files from Being Documented
+
+You can exclude one or multiple files from being documented by providing a list of glob patterns to 
+the `exclude` property in the configuration file.
+
+```typescript
+import { defineMarkdownConfig } from "@cparra/apexdocs";
+
+export default defineMarkdownConfig({
+  sourceDir: 'force-app',
+  targetDir: 'docs',
+  scope: ['global', 'public'],
+  exclude: ['**/MyClass.cls', '**/MyOtherClass.cls'],
+  ...
+});
+```
+
 ### Configuration Hooks
 
 When defining a `.js` or `.ts` configuration file, your object export can also make use

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cparra/apexdocs",
-  "version": "3.0.0-rc.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cparra/apexdocs",
-      "version": "3.0.0-rc.0",
+      "version": "3.1.1",
       "license": "MIT",
       "dependencies": {
         "@cparra/apex-reflection": "2.13.1",
@@ -19,6 +19,7 @@
         "fp-ts": "^2.16.8",
         "handlebars": "^4.7.8",
         "js-yaml": "^4.1.0",
+        "minimatch": "^10.0.1",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -29,7 +30,6 @@
         "@types/eslint__js": "^8.42.3",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.14.10",
-        "@types/shelljs": "^0.8.15",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "husky": "^9.0.11",
@@ -37,7 +37,7 @@
         "lint-staged": "^15.2.7",
         "pkgroll": "^2.4.2",
         "prettier": "^3.3.2",
-        "rimraf": "^6.0.0",
+        "rimraf": "^6.0.1",
         "ts-jest": "^29.2.0",
         "typescript": "^5.5.3",
         "typescript-eslint": "^7.16.0"
@@ -1034,6 +1034,16 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "13.24.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
@@ -1048,6 +1058,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/type-fest": {
@@ -1087,6 +1109,28 @@
       },
       "engines": {
         "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -2010,16 +2054,6 @@
         }
       }
     },
-    "node_modules/@rollup/plugin-commonjs/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/@rollup/plugin-commonjs/node_modules/glob": {
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
@@ -2508,16 +2542,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "*",
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -2573,12 +2597,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/minimatch": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
-      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
-      "dev": true
-    },
     "node_modules/@types/node": {
       "version": "20.14.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
@@ -2593,16 +2611,6 @@
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
       "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
       "dev": true
-    },
-    "node_modules/@types/shelljs": {
-      "version": "0.8.15",
-      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.15.tgz",
-      "integrity": "sha512-vzmnCHl6hViPu9GNLQJ+DZFd6BQI2DBTUeOvYHqkWQLMfKAAQYMb/xAmZkTogZI/vqXHCWkqDRymDI5p0QTi5Q==",
-      "dev": true,
-      "dependencies": {
-        "@types/glob": "~7.2.0",
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -2774,16 +2782,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -3020,17 +3018,14 @@
     "node_modules/balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/braces": {
@@ -3444,7 +3439,7 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
     "node_modules/cosmiconfig": {
@@ -3824,6 +3819,16 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/eslint/node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -3881,6 +3886,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/eslint/node_modules/p-limit": {
@@ -4374,6 +4391,28 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/globals": {
@@ -6541,15 +6580,17 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": "*"
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/minimist": {
@@ -7075,13 +7116,14 @@
       "license": "MIT"
     },
     "node_modules/rimraf": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.0.tgz",
-      "integrity": "sha512-u+yqhM92LW+89cxUQK0SRyvXYQmyuKHx0jkx4W7KfwLGLqJnQM5031Uv1trE4gB9XEXBM/s6MxKlfW95IidqaA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
+      "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "glob": "^11.0.0"
+        "glob": "^11.0.0",
+        "package-json-from-dist": "^1.0.0"
       },
       "bin": {
         "rimraf": "dist/esm/bin.mjs"
@@ -7091,16 +7133,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/rimraf/node_modules/glob": {
@@ -7119,22 +7151,6 @@
       },
       "bin": {
         "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/minimatch": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
-      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
       },
       "engines": {
         "node": "20 || >=22"
@@ -7487,6 +7503,28 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/text-table": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@types/eslint__js": "^8.42.3",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.14.10",
-    "@types/shelljs": "^0.8.15",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "husky": "^9.0.11",
@@ -46,7 +45,7 @@
     "lint-staged": "^15.2.7",
     "pkgroll": "^2.4.2",
     "prettier": "^3.3.2",
-    "rimraf": "^6.0.0",
+    "rimraf": "^6.0.1",
     "ts-jest": "^29.2.0",
     "typescript": "^5.5.3",
     "typescript-eslint": "^7.16.0"
@@ -72,6 +71,7 @@
     "fp-ts": "^2.16.8",
     "handlebars": "^4.7.8",
     "js-yaml": "^4.1.0",
+    "minimatch": "^10.0.1",
     "yargs": "^17.7.2"
   },
   "imports": {

--- a/src/application/Apexdocs.ts
+++ b/src/application/Apexdocs.ts
@@ -25,6 +25,7 @@ export class Apexdocs {
         new DefaultFileSystem(),
         config.sourceDir,
         config.targetGenerator === 'markdown' ? config.includeMetadata : false,
+        config.exclude,
       );
 
       switch (config.targetGenerator) {

--- a/src/application/__tests__/apex-file-reader.spec.ts
+++ b/src/application/__tests__/apex-file-reader.spec.ts
@@ -70,7 +70,7 @@ describe('File Reader', () => {
       },
     ]);
 
-    const result = await ApexFileReader.processFiles(fileSystem, '', false);
+    const result = await ApexFileReader.processFiles(fileSystem, '', false, []);
 
     expect(result.length).toBe(0);
   });
@@ -90,7 +90,7 @@ describe('File Reader', () => {
       },
     ]);
 
-    const result = await ApexFileReader.processFiles(fileSystem, '', false);
+    const result = await ApexFileReader.processFiles(fileSystem, '', false, []);
     expect(result.length).toBe(0);
   });
 
@@ -120,7 +120,7 @@ describe('File Reader', () => {
       },
     ]);
 
-    const result = await ApexFileReader.processFiles(fileSystem, '', false);
+    const result = await ApexFileReader.processFiles(fileSystem, '', false, []);
     expect(result.length).toBe(2);
     expect(result[0].content).toBe('public class MyClass{}');
     expect(result[1].content).toBe('public class AnotherClass{}');
@@ -174,7 +174,7 @@ describe('File Reader', () => {
       },
     ]);
 
-    const result = await ApexFileReader.processFiles(fileSystem, '', false);
+    const result = await ApexFileReader.processFiles(fileSystem, '', false, []);
     expect(result.length).toBe(4);
   });
 });

--- a/src/application/__tests__/apex-file-reader.spec.ts
+++ b/src/application/__tests__/apex-file-reader.spec.ts
@@ -126,6 +126,37 @@ describe('File Reader', () => {
     expect(result[1].content).toBe('public class AnotherClass{}');
   });
 
+  it('skips files that match the excluded glob pattern', async () => {
+    const fileSystem = new TestFileSystem([
+      {
+        type: 'directory',
+        path: '',
+        files: [
+          {
+            type: 'file',
+            path: 'SomeFile.cls',
+            content: 'public class MyClass{}',
+          },
+          {
+            type: 'directory',
+            path: 'subdir',
+            files: [
+              {
+                type: 'file',
+                path: 'AnotherFile.cls',
+                content: 'public class AnotherClass{}',
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+
+    const result = await ApexFileReader.processFiles(fileSystem, '', false, ['**/AnotherFile.cls']);
+    expect(result.length).toBe(1);
+    expect(result[0].content).toBe('public class MyClass{}');
+  });
+
   it('returns the file contents for all Apex  when there are multiple directories', async () => {
     const fileSystem = new TestFileSystem([
       {

--- a/src/application/apex-file-reader.ts
+++ b/src/application/apex-file-reader.ts
@@ -1,6 +1,8 @@
 import { FileSystem } from './file-system';
 import { UnparsedSourceFile } from '../core/shared/types';
 import { minimatch } from 'minimatch';
+import { pipe } from 'fp-ts/function';
+import { apply } from '#utils/fp';
 
 const APEX_FILE_EXTENSION = '.cls';
 
@@ -17,14 +19,14 @@ export class ApexFileReader {
     includeMetadata: boolean,
     exclude: string[],
   ): Promise<UnparsedSourceFile[]> {
-    // TODO: Make this more functional
-    // TODO: Unit tests
+    const processSingleFile = apply(this.processFile, fileSystem, includeMetadata);
 
-    const filePaths = await this.getFilePaths(fileSystem, rootPath);
-    const includedFilePaths = filePaths.filter((filePath) => !this.isExcluded(filePath, exclude));
-    const apexFilePaths = includedFilePaths.filter((filePath) => this.isApexFile(filePath));
-    const filePromises = apexFilePaths.map((filePath) => this.processFile(fileSystem, filePath, includeMetadata));
-    return Promise.all(filePromises);
+    return pipe(
+      await this.getFilePaths(fileSystem, rootPath),
+      (filePaths) => filePaths.filter((filePath) => !this.isExcluded(filePath, exclude)),
+      (filePaths) => filePaths.filter(this.isApexFile),
+      (filePaths) => Promise.all(filePaths.map(processSingleFile)),
+    );
   }
 
   private static async getFilePaths(fileSystem: FileSystem, rootPath: string): Promise<string[]> {
@@ -47,8 +49,8 @@ export class ApexFileReader {
 
   private static async processFile(
     fileSystem: FileSystem,
-    filePath: string,
     includeMetadata: boolean,
+    filePath: string,
   ): Promise<UnparsedSourceFile> {
     const rawTypeContent = await fileSystem.readFile(filePath);
     const metadataPath = `${filePath}-meta.xml`;

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -5,8 +5,13 @@ import { TypeScriptLoader } from 'cosmiconfig-typescript-loader';
 import { markdownOptions } from './commands/markdown';
 import { openApiOptions } from './commands/openapi';
 
-const configOnlyDefaults: Partial<UserDefinedMarkdownConfig> = {
+const configOnlyMarkdownDefaults: Partial<UserDefinedMarkdownConfig> = {
   excludeTags: [],
+  exclude: [],
+};
+
+const configOnlyOpenApiDefaults = {
+  exclude: [],
 };
 
 /**
@@ -48,8 +53,8 @@ export async function extractArgs(): Promise<UserDefinedConfig> {
 
   const mergedConfig = { ...config?.config, ...cliArgs, targetGenerator: commandName as 'markdown' | 'openapi' };
   if (mergedConfig.targetGenerator === 'markdown') {
-    return { ...configOnlyDefaults, ...mergedConfig };
+    return { ...configOnlyMarkdownDefaults, ...mergedConfig };
   } else {
-    return mergedConfig;
+    return { ...configOnlyOpenApiDefaults, ...mergedConfig };
   }
 }

--- a/src/core/markdown/__test__/test-helpers.ts
+++ b/src/core/markdown/__test__/test-helpers.ts
@@ -20,6 +20,7 @@ export function generateDocs(apexBundles: UnparsedSourceFile[], config?: Partial
     linkingStrategy: 'relative',
     excludeTags: [],
     referenceGuideTitle: 'Apex Reference Guide',
+    exclude: [],
     ...config,
   });
 }

--- a/src/core/markdown/adapters/__tests__/interface-adapter.spec.ts
+++ b/src/core/markdown/adapters/__tests__/interface-adapter.spec.ts
@@ -17,6 +17,7 @@ const defaultMarkdownGeneratorConfig: MarkdownGeneratorConfig = {
   sortAlphabetically: false,
   linkingStrategy: 'relative',
   referenceGuideTitle: 'Apex Reference Guide',
+  exclude: [],
   excludeTags: [],
 };
 

--- a/src/core/shared/types.d.ts
+++ b/src/core/shared/types.d.ts
@@ -23,6 +23,7 @@ export type UserDefinedMarkdownConfig = {
   linkingStrategy: LinkingStrategy;
   excludeTags: string[];
   referenceGuideTitle: string;
+  exclude: string[];
 } & Partial<ConfigurableHooks>;
 
 export type UserDefinedOpenApiConfig = {
@@ -33,6 +34,7 @@ export type UserDefinedOpenApiConfig = {
   namespace?: string;
   title: string;
   apiVersion: string;
+  exclude: string[];
 };
 
 export type UserDefinedConfig = UserDefinedMarkdownConfig | UserDefinedOpenApiConfig;

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,12 +12,9 @@ import type {
   TransformReference,
   ConfigurableDocPageReference,
   UserDefinedOpenApiConfig,
-  UserDefinedConfig,
 } from './core/shared/types';
 import { markdownDefaults, openApiDefaults } from './defaults';
-import { NoLogger } from '#utils/logger';
-import { Apexdocs } from './application/Apexdocs';
-import * as E from 'fp-ts/Either';
+import { process } from './node/process';
 
 type ConfigurableMarkdownConfig = Omit<Partial<UserDefinedMarkdownConfig>, 'targetGenerator'>;
 
@@ -54,39 +51,6 @@ function skip(): Skip {
   return {
     _tag: 'Skip',
   };
-}
-
-type CallableConfig = Partial<UserDefinedConfig> & { sourceDir: string; targetGenerator: 'markdown' | 'openapi' };
-
-async function process(config: CallableConfig): Promise<void> {
-  const logger = new NoLogger();
-  const configWithDefaults = {
-    ...getDefault(config),
-    ...config,
-  };
-
-  if (!configWithDefaults.sourceDir) {
-    throw new Error('sourceDir is required');
-  }
-
-  const result = await Apexdocs.generate(configWithDefaults as UserDefinedConfig, logger);
-  E.match(
-    (errors) => {
-      throw errors;
-    },
-    () => {},
-  )(result);
-}
-
-function getDefault(config: CallableConfig) {
-  switch (config.targetGenerator) {
-    case 'markdown':
-      return markdownDefaults;
-    case 'openapi':
-      return openApiDefaults;
-    default:
-      throw new Error('Unknown target generator');
-  }
 }
 
 export {

--- a/src/node/process.ts
+++ b/src/node/process.ts
@@ -1,0 +1,42 @@
+import type { UserDefinedConfig } from '../core/shared/types';
+import { NoLogger } from '#utils/logger';
+import { Apexdocs } from '../application/Apexdocs';
+import * as E from 'fp-ts/Either';
+import { markdownDefaults, openApiDefaults } from '../defaults';
+
+type CallableConfig = Partial<UserDefinedConfig> & { sourceDir: string; targetGenerator: 'markdown' | 'openapi' };
+
+/**
+ * Processes the documentation generation, similar to the main function in the CLI.
+ * @param config The configuration to use.
+ */
+export async function process(config: CallableConfig): Promise<void> {
+  const logger = new NoLogger();
+  const configWithDefaults = {
+    ...getDefault(config),
+    ...config,
+  };
+
+  if (!configWithDefaults.sourceDir) {
+    throw new Error('sourceDir is required');
+  }
+
+  const result = await Apexdocs.generate(configWithDefaults as UserDefinedConfig, logger);
+  E.match(
+    (errors) => {
+      throw errors;
+    },
+    () => {},
+  )(result);
+}
+
+function getDefault(config: CallableConfig) {
+  switch (config.targetGenerator) {
+    case 'markdown':
+      return markdownDefaults;
+    case 'openapi':
+      return openApiDefaults;
+    default:
+      throw new Error('Unknown target generator');
+  }
+}


### PR DESCRIPTION
A configuration property, `exclude`, can now be provided when using a configuration file (or the package.json config) that allows for a list of glob patterns to be provided that will skip any matched directory or file.