### PR TITLE
Add support to parse picklist values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ npm-debug.log
 /.idea/
 /dist/
 /lib/
+.sfdx/

--- a/examples/vitepress/docs/custom-objects/Price_Component__c.md
+++ b/examples/vitepress/docs/custom-objects/Price_Component__c.md
@@ -67,3 +67,8 @@ Use this when the Price Component represents a Flat Price. To represent a Percen
 **Type**
 
 *Picklist*
+
+#### Possible values are
+* List Price
+* Surcharge
+* Discount

--- a/examples/vitepress/docs/custom-objects/Sales_Order_Line__c.md
+++ b/examples/vitepress/docs/custom-objects/Sales_Order_Line__c.md
@@ -63,3 +63,7 @@ Represents a line item on a sales order.
 **Type**
 
 *Picklist*
+
+#### Possible values are
+* Charge
+* Discount

--- a/src/core/markdown/__test__/generating-custom-object-docs.spec.ts
+++ b/src/core/markdown/__test__/generating-custom-object-docs.spec.ts
@@ -1,6 +1,7 @@
 import { extendExpect } from './expect-extensions';
 import {
   customField,
+  customFieldPickListValues,
   customObjectGenerator,
   generateDocs,
   unparsedFieldBundleFromRawString,
@@ -46,7 +47,7 @@ describe('Generates Custom Object documentation', () => {
       expect(result).documentationBundleHasLength(1);
       assertEither(result, (data) => expect(data).firstDocContains('`TestObject__c`'));
     });
-
+    
     it('displays the Fields heading if fields are present', async () => {
       const customObjectBundle = unparsedObjectBundleFromRawString({
         rawContent: customObjectGenerator(),
@@ -62,6 +63,25 @@ describe('Generates Custom Object documentation', () => {
       const result = await generateDocs([customObjectBundle, customFieldBundle])();
       expect(result).documentationBundleHasLength(1);
       assertEither(result, (data) => expect(data).firstDocContains('## Fields'));
+    });
+
+    it('displays the pick list values name', async () => {
+      const customObjectBundle = unparsedObjectBundleFromRawString({
+        rawContent: customObjectGenerator(),
+        filePath: 'src/object/TestObject__c.object-meta.xml',
+      });
+
+      const customFieldBundle = unparsedFieldBundleFromRawString({
+        rawContent: customFieldPickListValues,
+        filePath: 'src/object/TestField__c.field-meta.xml',
+        parentName: 'TestObject__c',
+      });
+
+      const result = await generateDocs([customObjectBundle, customFieldBundle])();
+      expect(result).documentationBundleHasLength(1);
+      assertEither(result, (data) => expect(data).firstDocContains('* Staging'));
+      assertEither(result, (data) => expect(data).firstDocContains('* Active'));
+      assertEither(result, (data) => expect(data).firstDocContains('* Inactive'));
     });
 
     it('does not display the Fields heading if no fields are present', async () => {

--- a/src/core/markdown/__test__/test-helpers.ts
+++ b/src/core/markdown/__test__/test-helpers.ts
@@ -84,3 +84,36 @@ export const customField = `
     <type>Url</type>
     <description>A URL that points to a photo</description>
 </CustomField>`;
+
+export const customFieldPickListValues = `
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Status__c</fullName>
+          <externalId>false</externalId>
+          <label>Status</label>
+          <required>true</required>
+          <trackFeedHistory>false</trackFeedHistory>
+          <description>Status</description>
+          <type>Picklist</type>
+          <valueSet>
+              <restricted>true</restricted>
+              <valueSetDefinition>
+                  <sorted>false</sorted>
+                  <value>
+                      <fullName>Staging</fullName>
+                      <default>false</default>
+                      <label>Staging</label>
+                  </value>
+                  <value>
+                      <fullName>Active</fullName>
+                      <default>false</default>
+                      <label>Active</label>
+                  </value>
+                  <value>
+                      <fullName>Inactive</fullName>
+                      <default>false</default>
+                      <label>Inactive</label>
+                  </value>
+              </valueSetDefinition>
+          </valueSet>
+</CustomField>`;

--- a/src/core/markdown/adapters/type-to-renderable.ts
+++ b/src/core/markdown/adapters/type-to-renderable.ts
@@ -281,13 +281,11 @@ function fieldMetadataToRenderable(
     description: field.description ? [field.description] : [],
     apiName: getApiName(field.name, config),
     fieldType: field.type,
-    isPicklist: field.pickListValues.length > 0,
-    pickListValues: {
+    pickListValues: field.pickListValues ? {
       headingLevel: headingLevel + 1,
       heading: 'Possible values are',
-      value: field.pickListValues
-      
-    }
+      value: field.pickListValues,
+    } : undefined,
   };
 }
 

--- a/src/core/markdown/adapters/type-to-renderable.ts
+++ b/src/core/markdown/adapters/type-to-renderable.ts
@@ -281,6 +281,7 @@ function fieldMetadataToRenderable(
     description: field.description ? [field.description] : [],
     apiName: getApiName(field.name, config),
     fieldType: field.type,
+    pickListValues: field.pickListValues
   };
 }
 

--- a/src/core/markdown/adapters/type-to-renderable.ts
+++ b/src/core/markdown/adapters/type-to-renderable.ts
@@ -281,7 +281,13 @@ function fieldMetadataToRenderable(
     description: field.description ? [field.description] : [],
     apiName: getApiName(field.name, config),
     fieldType: field.type,
-    pickListValues: field.pickListValues
+    isPicklist: field.pickListValues.length > 0,
+    pickListValues: {
+      headingLevel: headingLevel + 1,
+      heading: 'Possible values are',
+      value: field.pickListValues
+      
+    }
   };
 }
 

--- a/src/core/markdown/templates/custom-object-template.ts
+++ b/src/core/markdown/templates/custom-object-template.ts
@@ -23,6 +23,9 @@ export const customObjectTemplate = `
 **Type**
 
 *{{fieldType}}*
+{{#each pickListValues}}
+* {{this}}
+{{/each}}
 {{/if}}
 
 {{#unless @last}}---{{/unless}}

--- a/src/core/markdown/templates/custom-object-template.ts
+++ b/src/core/markdown/templates/custom-object-template.ts
@@ -23,9 +23,13 @@ export const customObjectTemplate = `
 **Type**
 
 *{{fieldType}}*
-{{#each pickListValues}}
-* {{this}}
-{{/each}}
+
+{{#if isPicklist}}
+    {{ heading headingLevel heading }}
+    {{#each pickListValues.value}}
+    * {{{this}}}
+    {{/each}}
+{{/if}}
 {{/if}}
 
 {{#unless @last}}---{{/unless}}

--- a/src/core/markdown/templates/custom-object-template.ts
+++ b/src/core/markdown/templates/custom-object-template.ts
@@ -24,11 +24,11 @@ export const customObjectTemplate = `
 
 *{{fieldType}}*
 
-{{#if isPicklist}}
-    {{ heading headingLevel heading }}
-    {{#each pickListValues.value}}
-    * {{{this}}}
-    {{/each}}
+{{#if pickListValues}}
+{{ heading pickListValues.headingLevel pickListValues.heading }}
+{{#each pickListValues.value}}
+* {{{this}}}
+{{/each}}
 {{/if}}
 {{/if}}
 

--- a/src/core/reflection/sobject/__test__/reflect-custom-field-sources.spec.ts
+++ b/src/core/reflection/sobject/__test__/reflect-custom-field-sources.spec.ts
@@ -100,6 +100,52 @@ describe('when parsing custom field metadata', () => {
     assertEither(result, (data) => expect(data[0].type.description).toBe('A Photo URL field'));
   });
 
+  test('can parse picklist values', async() => {
+    const unparsed: UnparsedCustomFieldBundle = {
+      type: 'customfield',
+      name: 'Status__c',
+      parentName: 'MyFirstObject__c',
+      filePath: 'src/field/Status__c.field-meta.xml',
+      content: `
+      <?xml version="1.0" encoding="UTF-8"?>
+      <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+          <fullName>Status__c</fullName>
+          <externalId>false</externalId>
+          <label>Status</label>
+          <required>true</required>
+          <trackFeedHistory>false</trackFeedHistory>
+          <description>Status</description>
+          <type>Picklist</type>
+          <valueSet>
+              <restricted>true</restricted>
+              <valueSetDefinition>
+                  <sorted>false</sorted>
+                  <value>
+                      <fullName>Staging</fullName>
+                      <default>false</default>
+                      <label>Staging</label>
+                  </value>
+                  <value>
+                      <fullName>Active</fullName>
+                      <default>false</default>
+                      <label>Active</label>
+                  </value>
+                  <value>
+                      <fullName>Inactive</fullName>
+                      <default>false</default>
+                      <label>Inactive</label>
+                  </value>
+              </valueSetDefinition>
+          </valueSet>
+      </CustomField>`,
+    };
+
+    const result = await reflectCustomFieldSources([unparsed])();
+
+    assertEither(result, (data) => expect(data[0].type.description).toBe('Status'));
+    assertEither(result, (data) => expect(data[0].type.pickListValues).toEqual(['Staging', 'Active', 'Inactive']));
+  });
+
   test('An error is returned when the XML is in an invalid format', async () => {
     const unparsed: UnparsedCustomFieldBundle = {
       type: 'customfield',

--- a/src/core/reflection/sobject/reflect-custom-field-source.ts
+++ b/src/core/reflection/sobject/reflect-custom-field-source.ts
@@ -66,7 +66,7 @@ function toCustomFieldMetadata(parserResult: { CustomField: unknown }): CustomFi
   };
 
   const pickListValues =
-    isCustomField(customField) && customField.type === 'Picklist' ? toPickListValues(customField) : [];
+    hasType(customField) && customField.type?.toLowerCase() === 'picklist' ? toPickListValues(customField) : [];
   return { ...defaultValues, ...customField, type_name: 'customfield', pickListValues } as CustomFieldMetadata;
 }
 
@@ -85,7 +85,7 @@ function toPickListValues(customField: object): string[] {
   return [];
 }
 
-function isCustomField(customField: object): customField is CustomFieldMetadata {
+function hasType(customField: object): customField is CustomFieldMetadata {
   return (customField as CustomFieldMetadata).type != undefined;
 }
 

--- a/src/core/reflection/sobject/reflect-custom-field-source.ts
+++ b/src/core/reflection/sobject/reflect-custom-field-source.ts
@@ -15,6 +15,7 @@ export type CustomFieldMetadata = {
   label?: string | null;
   type?: string | null;
   parentName: string;
+  pickListValues: string[];
 };
 
 export function reflectCustomFieldSources(
@@ -58,12 +59,34 @@ function validate(parsedResult: unknown): E.Either<Error, { CustomField: unknown
 }
 
 function toCustomFieldMetadata(parserResult: { CustomField: unknown }): CustomFieldMetadata {
-  const customField = typeof parserResult.CustomField === 'object' ? parserResult.CustomField : {};
+  const customField =
+    parserResult?.CustomField != null && typeof parserResult.CustomField === 'object' ? parserResult.CustomField : {};
   const defaultValues = {
     description: null,
   };
 
-  return { ...defaultValues, ...customField, type_name: 'customfield' } as CustomFieldMetadata;
+  const pickListValues =
+    isCustomField(customField) && customField.type === 'Picklist' ? toPickListValues(customField) : [];
+  return { ...defaultValues, ...customField, type_name: 'customfield', pickListValues } as CustomFieldMetadata;
+}
+
+function toPickListValues(customField: object): string[] {
+  if ('valueSet' in customField) {
+    const valueSet = customField.valueSet as object;
+    if ('valueSetDefinition' in valueSet) {
+      const valueSetDefinition = valueSet.valueSetDefinition as object;
+      if ('value' in valueSetDefinition) {
+        const pickListValues = valueSetDefinition.value as object[];
+        return pickListValues.filter((each) => 'fullName' in each).map((each) => each.fullName as string);
+      }
+    }
+  }
+
+  return [];
+}
+
+function isCustomField(customField: object): customField is CustomFieldMetadata {
+  return (customField as CustomFieldMetadata).type != undefined;
 }
 
 function addName(metadata: CustomFieldMetadata, name: string): CustomFieldMetadata {

--- a/src/core/reflection/sobject/reflect-custom-field-source.ts
+++ b/src/core/reflection/sobject/reflect-custom-field-source.ts
@@ -15,7 +15,7 @@ export type CustomFieldMetadata = {
   label?: string | null;
   type?: string | null;
   parentName: string;
-  pickListValues: string[];
+  pickListValues?: string[];
 };
 
 export function reflectCustomFieldSources(
@@ -66,7 +66,7 @@ function toCustomFieldMetadata(parserResult: { CustomField: unknown }): CustomFi
   };
 
   const pickListValues =
-    hasType(customField) && customField.type?.toLowerCase() === 'picklist' ? toPickListValues(customField) : [];
+    hasType(customField) && customField.type?.toLowerCase() === 'picklist' ? toPickListValues(customField) : undefined;
   return { ...defaultValues, ...customField, type_name: 'customfield', pickListValues } as CustomFieldMetadata;
 }
 
@@ -86,7 +86,7 @@ function toPickListValues(customField: object): string[] {
 }
 
 function hasType(customField: object): customField is CustomFieldMetadata {
-  return (customField as CustomFieldMetadata).type != undefined;
+  return !!(customField as CustomFieldMetadata).type;
 }
 
 function addName(metadata: CustomFieldMetadata, name: string): CustomFieldMetadata {

--- a/src/core/renderables/types.d.ts
+++ b/src/core/renderables/types.d.ts
@@ -189,7 +189,6 @@ export type RenderableCustomField = {
   heading: string;
   apiName: string;
   description: RenderableContent[];
-  isPicklist: boolean;
   pickListValues?: RenderableSection<string[]>
   type: 'field';
   fieldType?: string | null;

--- a/src/core/renderables/types.d.ts
+++ b/src/core/renderables/types.d.ts
@@ -189,6 +189,7 @@ export type RenderableCustomField = {
   heading: string;
   apiName: string;
   description: RenderableContent[];
+  pickListValues: string[];
   type: 'field';
   fieldType?: string | null;
 };

--- a/src/core/renderables/types.d.ts
+++ b/src/core/renderables/types.d.ts
@@ -189,7 +189,8 @@ export type RenderableCustomField = {
   heading: string;
   apiName: string;
   description: RenderableContent[];
-  pickListValues: string[];
+  isPicklist: boolean;
+  pickListValues?: RenderableSection<string[]>
   type: 'field';
   fieldType?: string | null;
 };


### PR DESCRIPTION
When generating documentation for custom objects, include pick list values in documentation

TODO:

- [x] Ensure documentation generator to include pick list values