### PR TITLE
Documenting extension fields

### DIFF
--- a/examples/vitepress/docs/.vitepress/sidebar.json
+++ b/examples/vitepress/docs/.vitepress/sidebar.json
@@ -59,6 +59,10 @@
     "text": "Object Reference",
     "items": [
       {
+        "text": "Contact",
+        "link": "custom-objects/Contact.md"
+      },
+      {
         "text": "Event__c",
         "link": "custom-objects/Event__c.md"
       },

--- a/examples/vitepress/docs/changelog.md
+++ b/examples/vitepress/docs/changelog.md
@@ -68,3 +68,4 @@ Custom object for tracking sales orders.
 ### Speaker__c
 
 Represents a speaker at an event.
+### Contact

--- a/examples/vitepress/docs/changelog.md
+++ b/examples/vitepress/docs/changelog.md
@@ -68,4 +68,11 @@ Custom object for tracking sales orders.
 ### Speaker__c
 
 Represents a speaker at an event.
+
+## New or Removed Fields to Custom Objects or Standard Objects
+
+These custom fields have been added or removed.
+
 ### Contact
+
+- New Field: PhotoUrl__c

--- a/examples/vitepress/docs/custom-objects/Contact.md
+++ b/examples/vitepress/docs/custom-objects/Contact.md
@@ -1,0 +1,19 @@
+---
+title: Contact
+---
+
+# Contact
+
+## API Name
+`apexdocs__Contact`
+
+## Fields
+### PhotoUrl
+
+**API Name**
+
+`apexdocs__PhotoUrl__c`
+
+**Type**
+
+*Url*

--- a/examples/vitepress/docs/custom-objects/Product_Inline_Fields__c.md
+++ b/examples/vitepress/docs/custom-objects/Product_Inline_Fields__c.md
@@ -21,3 +21,92 @@ The date the product got discontinued
 **Type**
 
 *DateTime*
+
+---
+### ID
+
+**API Name**
+
+`apexdocs__ID__c`
+
+**Type**
+
+*Number*
+
+---
+### Name
+
+Product name
+
+**API Name**
+
+`apexdocs__Name__c`
+
+**Type**
+
+*Text*
+
+---
+### Price
+
+Product price in the default currency
+
+**API Name**
+
+`apexdocs__Price__c`
+
+**Type**
+
+*Number*
+
+---
+### Products
+
+**API Name**
+
+`apexdocs__Products__c`
+
+**Type**
+
+*ExternalLookup*
+
+---
+### Rating
+
+Rating
+
+**API Name**
+
+`apexdocs__Rating__c`
+
+**Type**
+
+*Number*
+
+---
+### ReleaseDate
+
+ReleaseDate
+
+**API Name**
+
+`apexdocs__ReleaseDate__c`
+
+**Type**
+
+*DateTime*
+
+---
+### Type
+
+**API Name**
+
+`apexdocs__Type__c`
+
+**Type**
+
+*Picklist*
+
+#### Possible values are
+* Merchandise
+* Bundle

--- a/examples/vitepress/docs/index.md
+++ b/examples/vitepress/docs/index.md
@@ -19,6 +19,8 @@ hero:
 
 ## Custom Objects
 
+### [Contact](custom-objects/Contact)
+
 ### [Event__c](custom-objects/Event__c)
 
 Represents an event that people can register for.

--- a/src/core/changelog/__test__/generating-change-log.spec.ts
+++ b/src/core/changelog/__test__/generating-change-log.spec.ts
@@ -347,7 +347,9 @@ describe('when generating a changelog', () => {
       const result = await generateChangeLog(oldBundle, newBundle, config)();
 
       assertEither(result, (data) =>
-        expect((data as ChangeLogPageData).content).toContain('## New or Removed Fields in Existing Objects'),
+        expect((data as ChangeLogPageData).content).toContain(
+          '## New or Removed Fields to Custom Objects or Standard Objects',
+        ),
       );
     });
 

--- a/src/core/changelog/generate-change-log.ts
+++ b/src/core/changelog/generate-change-log.ts
@@ -72,7 +72,6 @@ function reflect(bundles: UnparsedSourceBundle[], config: Omit<UserDefinedChange
   );
 }
 
-// TODO: UTs
 function toManifests({ oldVersion, newVersion }: { oldVersion: ParsedFile[]; newVersion: ParsedFile[] }) {
   function parsedFilesToManifest(parsedFiles: ParsedFile[]): VersionManifest {
     return {

--- a/src/core/changelog/generate-change-log.ts
+++ b/src/core/changelog/generate-change-log.ts
@@ -15,11 +15,12 @@ import { changelogTemplate } from './templates/changelog-template';
 import { ReflectionErrors } from '../errors/errors';
 import { apply } from '#utils/fp';
 import { filterScope } from '../reflection/apex/filter-scope';
-import { skip } from '../shared/utils';
+import { isInSource, skip } from '../shared/utils';
 import { reflectCustomFieldsAndObjects } from '../reflection/sobject/reflectCustomFieldsAndObjects';
 import { CustomObjectMetadata } from '../reflection/sobject/reflect-custom-object-sources';
 import { Type } from '@cparra/apex-reflection';
 import { filterApexSourceFiles, filterCustomObjectsAndFields } from '#utils/source-bundle-utils';
+import { CustomFieldMetadata } from '../reflection/sobject/reflect-custom-field-source';
 
 export type ChangeLogPageData = {
   content: string;
@@ -71,16 +72,21 @@ function reflect(bundles: UnparsedSourceBundle[], config: Omit<UserDefinedChange
   );
 }
 
-function toManifests({
-  oldVersion,
-  newVersion,
-}: {
-  oldVersion: ParsedFile<Type | CustomObjectMetadata>[];
-  newVersion: ParsedFile<Type | CustomObjectMetadata>[];
-}) {
-  function parsedFilesToManifest(parsedFiles: ParsedFile<Type | CustomObjectMetadata>[]): VersionManifest {
+// TODO: UTs
+function toManifests({ oldVersion, newVersion }: { oldVersion: ParsedFile[]; newVersion: ParsedFile[] }) {
+  function parsedFilesToManifest(parsedFiles: ParsedFile[]): VersionManifest {
     return {
-      types: parsedFiles.map((parsedFile) => parsedFile.type),
+      types: parsedFiles.reduce(
+        (previousValue: (Type | CustomObjectMetadata | CustomFieldMetadata)[], parsedFile: ParsedFile) => {
+          if (!isInSource(parsedFile.source) && parsedFile.type.type_name === 'customobject') {
+            // When we are dealing with a custom object that was not in the source (for extension fields), we return all
+            // of its fields.
+            return [...previousValue, ...parsedFile.type.fields];
+          }
+          return [...previousValue, parsedFile.type];
+        },
+        [] as (Type | CustomObjectMetadata | CustomFieldMetadata)[],
+      ),
     };
   }
 

--- a/src/core/changelog/process-changelog.ts
+++ b/src/core/changelog/process-changelog.ts
@@ -109,7 +109,6 @@ function getCustomObjectModifications(oldVersion: VersionManifest, newVersion: V
   );
 }
 
-// TODO: UTs
 function getNewOrModifiedExtensionFields(
   oldVersion: VersionManifest,
   newVersion: VersionManifest,

--- a/src/core/changelog/renderable-changelog.ts
+++ b/src/core/changelog/renderable-changelog.ts
@@ -3,6 +3,7 @@ import { ClassMirror, EnumMirror, InterfaceMirror, Type } from '@cparra/apex-ref
 import { RenderableContent } from '../renderables/types';
 import { adaptDescribable } from '../renderables/documentables';
 import { CustomObjectMetadata } from '../reflection/sobject/reflect-custom-object-sources';
+import { CustomFieldMetadata } from '../reflection/sobject/reflect-custom-field-source';
 
 type NewTypeRenderable = {
   name: string;
@@ -46,7 +47,7 @@ export type RenderableChangelog = {
 
 export function convertToRenderableChangelog(
   changelog: Changelog,
-  newManifest: (Type | CustomObjectMetadata)[],
+  newManifest: (Type | CustomObjectMetadata | CustomFieldMetadata)[],
 ): RenderableChangelog {
   const allNewTypes = [...changelog.newApexTypes, ...changelog.newCustomObjects].map(
     (newType) => newManifest.find((type) => type.name.toLowerCase() === newType.toLowerCase())!,
@@ -122,7 +123,7 @@ export function convertToRenderableChangelog(
     newOrRemovedCustomFields:
       changelog.customObjectModifications.length > 0
         ? {
-            heading: 'New or Removed Fields in Existing Objects',
+            heading: 'New or Removed Fields to Custom Objects or Standard Objects',
             description: 'These custom fields have been added or removed.',
             modifications: changelog.customObjectModifications.map(toRenderableModification),
           }

--- a/src/core/markdown/adapters/type-to-renderable.ts
+++ b/src/core/markdown/adapters/type-to-renderable.ts
@@ -17,9 +17,9 @@ import { adaptDescribable, adaptDocumentable } from '../../renderables/documenta
 import { adaptConstructor, adaptMethod } from './methods-and-constructors';
 import { adaptFieldOrProperty } from './fields-and-properties';
 import { MarkdownGeneratorConfig } from '../generate-docs';
-import { SourceFileMetadata } from '../../shared/types';
+import { ExternalMetadata, SourceFileMetadata } from '../../shared/types';
 import { CustomObjectMetadata } from '../../reflection/sobject/reflect-custom-object-sources';
-import { getTypeGroup } from '../../shared/utils';
+import { getTypeGroup, isInSource } from '../../shared/utils';
 import { CustomFieldMetadata } from '../../reflection/sobject/reflect-custom-field-source';
 
 type GetReturnRenderable<T extends Type | CustomObjectMetadata> = T extends InterfaceMirror
@@ -31,10 +31,10 @@ type GetReturnRenderable<T extends Type | CustomObjectMetadata> = T extends Inte
       : RenderableCustomObject;
 
 export function typeToRenderable<T extends Type | CustomObjectMetadata>(
-  parsedFile: { source: SourceFileMetadata; type: T },
+  parsedFile: { source: SourceFileMetadata | ExternalMetadata; type: T },
   linkGenerator: GetRenderableContentByTypeName,
   config: MarkdownGeneratorConfig,
-): GetReturnRenderable<T> & { filePath: string; namespace?: string } {
+): GetReturnRenderable<T> & { filePath: string | undefined; namespace?: string } {
   function getRenderable(): RenderableInterface | RenderableClass | RenderableEnum | RenderableCustomObject {
     const { type } = parsedFile;
     switch (type.type_name) {
@@ -51,7 +51,7 @@ export function typeToRenderable<T extends Type | CustomObjectMetadata>(
 
   return {
     ...(getRenderable() as GetReturnRenderable<T>),
-    filePath: parsedFile.source.filePath,
+    filePath: isInSource(parsedFile.source) ? parsedFile.source.filePath : undefined,
     namespace: config.namespace,
   };
 }
@@ -281,11 +281,13 @@ function fieldMetadataToRenderable(
     description: field.description ? [field.description] : [],
     apiName: getApiName(field.name, config),
     fieldType: field.type,
-    pickListValues: field.pickListValues ? {
-      headingLevel: headingLevel + 1,
-      heading: 'Possible values are',
-      value: field.pickListValues,
-    } : undefined,
+    pickListValues: field.pickListValues
+      ? {
+          headingLevel: headingLevel + 1,
+          heading: 'Possible values are',
+          value: field.pickListValues,
+        }
+      : undefined,
   };
 }
 

--- a/src/core/reflection/apex/reflect-apex-source.ts
+++ b/src/core/reflection/apex/reflect-apex-source.ts
@@ -11,6 +11,7 @@ import { Semigroup } from 'fp-ts/Semigroup';
 import { ParsedFile, UnparsedApexBundle } from '../../shared/types';
 import { ReflectionError, ReflectionErrors } from '../../errors/errors';
 import { parseApexMetadata } from './parse-apex-metadata';
+import { isInSource } from '../../shared/utils';
 
 async function reflectAsync(rawSource: string): Promise<Type> {
   return new Promise((resolve, reject) => {
@@ -69,7 +70,9 @@ function addMetadata(
       parsedFile.type,
       (type) => addFileMetadataToTypeAnnotation(type as Type, rawMetadataContent),
       E.map((type) => ({ ...parsedFile, type })),
-      E.mapLeft((error) => errorToReflectionErrors(error, parsedFile.source.filePath)),
+      E.mapLeft((error) =>
+        errorToReflectionErrors(error, isInSource(parsedFile.source) ? parsedFile.source.filePath : ''),
+      ),
     ),
   );
 }

--- a/src/core/reflection/sobject/__test__/reflect-custom-field-sources.spec.ts
+++ b/src/core/reflection/sobject/__test__/reflect-custom-field-sources.spec.ts
@@ -2,6 +2,7 @@ import { UnparsedCustomFieldBundle } from '../../../shared/types';
 import { reflectCustomFieldSources } from '../reflect-custom-field-source';
 import { assertEither } from '../../../test-helpers/assert-either';
 import * as E from 'fp-ts/Either';
+import { isInSource } from '../../../shared/utils';
 
 const customFieldContent = `
 <?xml version="1.0" encoding="UTF-8"?>
@@ -27,7 +28,13 @@ describe('when parsing custom field metadata', () => {
 
     const result = await reflectCustomFieldSources([unparsed])();
 
-    assertEither(result, (data) => expect(data[0].source.filePath).toBe('src/field/PhotoUrl__c.field-meta.xml'));
+    assertEither(result, (data) => {
+      if (isInSource(data[0].source)) {
+        expect(data[0].source.filePath).toBe('src/field/PhotoUrl__c.field-meta.xml');
+      } else {
+        fail('Expected the source to be in the source');
+      }
+    });
   });
 
   test('the resulting type contains the correct name', async () => {
@@ -100,7 +107,7 @@ describe('when parsing custom field metadata', () => {
     assertEither(result, (data) => expect(data[0].type.description).toBe('A Photo URL field'));
   });
 
-  test('can parse picklist values', async() => {
+  test('can parse picklist values', async () => {
     const unparsed: UnparsedCustomFieldBundle = {
       type: 'customfield',
       name: 'Status__c',

--- a/src/core/reflection/sobject/__test__/reflect-custom-object-sources.spec.ts
+++ b/src/core/reflection/sobject/__test__/reflect-custom-object-sources.spec.ts
@@ -6,6 +6,7 @@ import {
   CustomObjectXmlBuilder,
   InlineFieldBuilder,
 } from '../../../test-helpers/test-data-builders/custom-object-xml-builder';
+import { isInSource } from '../../../shared/utils';
 
 describe('when parsing SObject metadata', () => {
   test('the resulting type contains the file path', async () => {
@@ -18,7 +19,13 @@ describe('when parsing SObject metadata', () => {
 
     const result = await reflectCustomObjectSources([unparsed])();
 
-    assertEither(result, (data) => expect(data[0].source.filePath).toBe('src/object/MyFirstObject__c.object-meta.xml'));
+    assertEither(result, (data) => {
+      if (isInSource(data[0].source)) {
+        expect(data[0].source.filePath).toBe('src/object/MyFirstObject__c.object-meta.xml');
+      } else {
+        fail('Expected the source to be in the source');
+      }
+    });
   });
 
   test('the resulting type contains the correct label', async () => {

--- a/src/core/reflection/sobject/reflectCustomFieldsAndObjects.ts
+++ b/src/core/reflection/sobject/reflectCustomFieldsAndObjects.ts
@@ -86,7 +86,6 @@ function mapExtensionFields(
     const fields = extensionFieldsByParent[key];
     return {
       source: {
-        filePath: '',
         name: key,
         type: 'customobject',
       },

--- a/src/core/reflection/sobject/reflectCustomFieldsAndObjects.ts
+++ b/src/core/reflection/sobject/reflectCustomFieldsAndObjects.ts
@@ -38,18 +38,67 @@ export function reflectCustomFieldsAndObjects(
     TE.map(filterNonPublic),
     TE.bindTo('objects'),
     TE.bind('fields', () => generateForFields(customFields)),
-    // Locate the fields for each object by using the parentName property
     TE.map(({ objects, fields }) => {
-      return objects.map((object) => {
-        const objectFields = fields.filter((field) => field.type.parentName === object.type.name);
-        return {
-          ...object,
-          type: {
-            ...object.type,
-            fields: [...object.type.fields, ...objectFields.map((field) => field.type)],
-          },
-        };
-      });
+      return [...mapFieldsToObjects(objects, fields), ...mapExtensionFields(objects, fields)];
     }),
   );
+}
+
+function mapFieldsToObjects(
+  objects: ParsedFile<CustomObjectMetadata>[],
+  fields: ParsedFile<CustomFieldMetadata>[],
+): ParsedFile<CustomObjectMetadata>[] {
+  // Locate the fields for each object by using the parentName property
+  return objects.map((object) => {
+    const objectFields = fields.filter((field) => field.type.parentName === object.type.name);
+    return {
+      ...object,
+      type: {
+        ...object.type,
+        fields: [...object.type.fields, ...objectFields.map((field) => field.type)],
+      },
+    };
+  });
+}
+
+// "Extension" fields are fields that are in the source code without the corresponding object-meta.xml file.
+// These are fields that either extend a standard Salesforce object, or an object in a different package.
+function mapExtensionFields(
+  objects: ParsedFile<CustomObjectMetadata>[],
+  fields: ParsedFile<CustomFieldMetadata>[],
+): ParsedFile<CustomObjectMetadata>[] {
+  const extensionFields = fields.filter(
+    (field) => !objects.some((object) => object.type.name === field.type.parentName),
+  );
+  // There might be many objects for the same parent name, so we need to group the fields by parent name
+  const extensionFieldsByParent = extensionFields.reduce(
+    (acc, field) => {
+      if (!acc[field.type.parentName]) {
+        acc[field.type.parentName] = [];
+      }
+      acc[field.type.parentName].push(field.type);
+      return acc;
+    },
+    {} as Record<string, CustomFieldMetadata[]>,
+  );
+
+  return Object.keys(extensionFieldsByParent).map((key) => {
+    const fields = extensionFieldsByParent[key];
+    return {
+      source: {
+        filePath: '',
+        name: key,
+        type: 'customobject',
+      },
+      type: {
+        type_name: 'customobject',
+        deploymentStatus: 'Deployed',
+        visibility: 'Public',
+        label: key,
+        name: key,
+        description: null,
+        fields: fields,
+      },
+    };
+  });
 }

--- a/src/core/renderables/types.d.ts
+++ b/src/core/renderables/types.d.ts
@@ -189,11 +189,11 @@ export type RenderableCustomField = {
   heading: string;
   apiName: string;
   description: RenderableContent[];
-  pickListValues?: RenderableSection<string[]>
+  pickListValues?: RenderableSection<string[]>;
   type: 'field';
   fieldType?: string | null;
 };
 
 export type Renderable = (RenderableClass | RenderableInterface | RenderableEnum | RenderableCustomObject) & {
-  filePath: string;
+  filePath: string | undefined;
 };

--- a/src/core/shared/types.d.ts
+++ b/src/core/shared/types.d.ts
@@ -85,21 +85,34 @@ export type UnparsedApexBundle = {
   metadataContent: string | null;
 };
 
+type MetadataTypes = 'interface' | 'class' | 'enum' | 'customobject' | 'customfield';
+
 export type SourceFileMetadata = {
   filePath: string;
   name: string;
-  type: 'interface' | 'class' | 'enum' | 'customobject' | 'customfield';
+  type: MetadataTypes;
+};
+
+// External metadata is metadata that does not live directly in the source code, and thus we don't
+// have a file path for it.
+// This is metadata derived from other information.
+// For example, for an "extension"
+// field that extends a Salesforce object or object in a different package, we want to capture the parent
+// object, even if the file for that object was not parsed.
+export type ExternalMetadata = {
+  name: string;
+  type: MetadataTypes;
 };
 
 export type ParsedFile<
   T extends Type | CustomObjectMetadata | CustomFieldMetadata = Type | CustomObjectMetadata | CustomFieldMetadata,
 > = {
-  source: SourceFileMetadata;
+  source: SourceFileMetadata | ExternalMetadata;
   type: T;
 };
 
 export type DocPageReference = {
-  source: SourceFileMetadata;
+  source: SourceFileMetadata | ExternalMetadata;
   // The name under which the type should be displayed in the documentation.
   // By default, this will match the source.name, but it can be configured by the user.
   displayName: string;
@@ -121,7 +134,7 @@ export type ReferenceGuidePageData = {
 };
 
 export type DocPageData = {
-  source: SourceFileMetadata;
+  source: SourceFileMetadata | ExternalMetadata;
   group: string | null;
   outputDocPath: string;
   frontmatter: Frontmatter;

--- a/src/core/shared/utils.ts
+++ b/src/core/shared/utils.ts
@@ -1,4 +1,4 @@
-import { Skip } from './types';
+import { ExternalMetadata, Skip, SourceFileMetadata } from './types';
 import { Type } from '@cparra/apex-reflection';
 import { CustomObjectMetadata } from '../reflection/sobject/reflect-custom-object-sources';
 import { MarkdownGeneratorConfig } from '../markdown/generate-docs';
@@ -23,6 +23,10 @@ export function isObjectType(type: Type | CustomObjectMetadata | CustomFieldMeta
 
 export function isApexType(type: Type | CustomObjectMetadata | CustomFieldMetadata): type is Type {
   return !isObjectType(type);
+}
+
+export function isInSource(source: SourceFileMetadata | ExternalMetadata): source is SourceFileMetadata {
+  return 'filePath' in source;
 }
 
 export function getTypeGroup(type: Type | CustomObjectMetadata, config: MarkdownGeneratorConfig): string {

--- a/src/core/test-helpers/test-data-builders/custom-field-xml-builder.ts
+++ b/src/core/test-helpers/test-data-builders/custom-field-xml-builder.ts
@@ -1,0 +1,15 @@
+export class CustomFieldXmlBuilder {
+  build(): string {
+    return `
+      <?xml version="1.0" encoding="UTF-8"?>
+      <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+          <fullName>PhotoUrl__c</fullName>
+          <externalId>false</externalId>
+          <label>PhotoUrl</label>
+          <required>false</required>
+          <trackFeedHistory>false</trackFeedHistory>
+          <type>Url</type>
+          <description>A URL that points to a photo</description>
+      </CustomField>`;
+  }
+}


### PR DESCRIPTION
Adds support for "extension" fields. These are fields that are in the source code without the parent `object-meta.xml` file. These usually extend a standard object or an object from a different package.