### PR TITLE
Add compliance category and security classification

### DIFF
--- a/src/core/changelog/__test__/helpers/custom-field-metadata-builder.ts
+++ b/src/core/changelog/__test__/helpers/custom-field-metadata-builder.ts
@@ -23,6 +23,8 @@ export default class CustomFieldMetadataBuilder {
       description: this.description,
       parentName: 'MyObject',
       required: false,
+      securityClassification: 'Internal',
+      complianceCategory: 'PII',
     };
   }
 }

--- a/src/core/reflection/sobject/__test__/reflect-custom-field-sources.spec.ts
+++ b/src/core/reflection/sobject/__test__/reflect-custom-field-sources.spec.ts
@@ -14,6 +14,8 @@ const customFieldContent = `
     <trackFeedHistory>false</trackFeedHistory>
     <type>Url</type>
     <description>A Photo URL field</description>
+    <securityClassification>Internal</securityClassification>
+    <complianceCategory>PII</complianceCategory>
 </CustomField>`;
 
 describe('when parsing custom field metadata', () => {
@@ -105,6 +107,34 @@ describe('when parsing custom field metadata', () => {
     const result = await reflectCustomFieldSources([unparsed])();
 
     assertEither(result, (data) => expect(data[0].type.description).toBe('A Photo URL field'));
+  });
+
+  test('the resulting type contains the correct security classification', async () => {
+    const unparsed: UnparsedCustomFieldBundle = {
+      type: 'customfield',
+      name: 'PhotoUrl__c',
+      parentName: 'MyFirstObject__c',
+      filePath: 'src/field/PhotoUrl__c.field-meta.xml',
+      content: customFieldContent,
+    };
+
+    const result = await reflectCustomFieldSources([unparsed])();
+
+    assertEither(result, (data) => expect(data[0].type.securityClassification).toBe('Internal'));
+  });
+
+  test('the resulting type contains the correct compliance category', async () => {
+    const unparsed: UnparsedCustomFieldBundle = {
+      type: 'customfield',
+      name: 'PhotoUrl__c',
+      parentName: 'MyFirstObject__c',
+      filePath: 'src/field/PhotoUrl__c.field-meta.xml',
+      content: customFieldContent,
+    };
+
+    const result = await reflectCustomFieldSources([unparsed])();
+
+    assertEither(result, (data) => expect(data[0].type.complianceCategory).toBe('PII'));
   });
 
   test('can parse picklist values when there are multiple picklist values available', async () => {

--- a/src/core/reflection/sobject/reflect-custom-field-source.ts
+++ b/src/core/reflection/sobject/reflect-custom-field-source.ts
@@ -18,6 +18,8 @@ export type CustomFieldMetadata = {
   parentName: string;
   pickListValues?: string[];
   required: boolean;
+  securityClassification: string | null;
+  complianceCategory: string | null;
 };
 
 export function reflectCustomFieldSources(
@@ -66,6 +68,8 @@ function toCustomFieldMetadata(parserResult: { CustomField: unknown }): CustomFi
   const defaultValues = {
     description: null,
     required: false,
+    securityClassification: null,
+    complianceCategory: null,
   };
 
   return {

--- a/src/core/reflection/sobject/reflect-custom-object-sources.ts
+++ b/src/core/reflection/sobject/reflect-custom-object-sources.ts
@@ -109,6 +109,8 @@ function convertInlineFieldsToCustomFieldMetadata(
   const label = inlineField.label ? (inlineField.label as string) : name;
   const type = inlineField.type ? (inlineField.type as string) : null;
   const required = inlineField.required ? (inlineField.required as boolean) : false;
+  const securityClassification = inlineField.securityClassification ? (inlineField.securityClassification as string) : null;
+  const complianceCategory = inlineField.complianceCategory ? (inlineField.complianceCategory as string) : null;
 
   return {
     type_name: 'customfield',
@@ -118,6 +120,8 @@ function convertInlineFieldsToCustomFieldMetadata(
     parentName,
     type,
     required,
+    securityClassification,
+    complianceCategory,
     pickListValues: getPickListValues(inlineField),
   };
 }


### PR DESCRIPTION
Add compliance category and security classification to metadata that is retrieved for custom fields. We have a need on projects at Salesforce consulting to set both values for various industries ranging from FinRa to FedRamp. I need to have the ability to grab this data along with the provided metadata for fields.