### PR TITLE
Add compliance category and security classification to Custom Field

### DIFF
--- a/examples/markdown/docs/custom-objects/Event__c.md
+++ b/examples/markdown/docs/custom-objects/Event__c.md
@@ -41,6 +41,25 @@ Represents an event that people can register for.
 *Location*
 
 ---
+### Social Security Number
+
+Used to store the U.S. social security number in 9 digit format.
+
+**Compliance Category**
+PII
+
+**Security Classification**
+Internal
+
+**API Name**
+
+`ns__Social_Security_Number__c`
+
+**Type**
+
+*Text*
+
+---
 ### Start Date
 **Required**
 

--- a/examples/markdown/force-app/objects/Event__c/fields/Social_Security_Number__c.field-meta.xml
+++ b/examples/markdown/force-app/objects/Event__c/fields/Social_Security_Number__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Social_Security_Number__c</fullName>
+    <externalId>false</externalId>
+    <label>Social Security Number</label>
+    <description>Used to store the U.S. social security number in 9 digit format.</description>
+    <length>9</length>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <complianceCategory>PII</complianceCategory>
+    <securityClassification>Internal</securityClassification>
+</CustomField>

--- a/src/core/changelog/__test__/helpers/custom-field-metadata-builder.ts
+++ b/src/core/changelog/__test__/helpers/custom-field-metadata-builder.ts
@@ -23,6 +23,8 @@ export default class CustomFieldMetadataBuilder {
       description: this.description,
       parentName: 'MyObject',
       required: false,
+      securityClassification: 'Internal',
+      complianceCategory: 'PII',
     };
   }
 }

--- a/src/core/markdown/adapters/type-to-renderable.ts
+++ b/src/core/markdown/adapters/type-to-renderable.ts
@@ -357,6 +357,8 @@ function fieldMetadataToRenderable(
     apiName: getApiName(field.name, config),
     fieldType: field.type,
     required: field.required,
+    complianceCategory: field.complianceCategory,
+    securityClassification: field.securityClassification,
     pickListValues: field.pickListValues
       ? {
           headingLevel: headingLevel + 1,

--- a/src/core/markdown/templates/custom-object-template.ts
+++ b/src/core/markdown/templates/custom-object-template.ts
@@ -24,6 +24,16 @@ export const customObjectTemplate = `
 {{{renderContent description}}}
 {{/if}}
 
+{{#if complianceCategory}}
+**Compliance Category**
+{{complianceCategory}}
+{{/if}}
+
+{{#if securityClassification}}
+**Security Classification**
+{{securityClassification}}
+{{/if}}
+
 **API Name**
 
 \`{{{apiName}}}\`

--- a/src/core/reflection/sobject/__test__/reflect-custom-field-sources.spec.ts
+++ b/src/core/reflection/sobject/__test__/reflect-custom-field-sources.spec.ts
@@ -14,6 +14,8 @@ const customFieldContent = `
     <trackFeedHistory>false</trackFeedHistory>
     <type>Url</type>
     <description>A Photo URL field</description>
+    <securityClassification>Internal</securityClassification>
+    <complianceCategory>PII</complianceCategory>
 </CustomField>`;
 
 describe('when parsing custom field metadata', () => {
@@ -105,6 +107,34 @@ describe('when parsing custom field metadata', () => {
     const result = await reflectCustomFieldSources([unparsed])();
 
     assertEither(result, (data) => expect(data[0].type.description).toBe('A Photo URL field'));
+  });
+
+  test('the resulting type contains the correct security classification', async () => {
+    const unparsed: UnparsedCustomFieldBundle = {
+      type: 'customfield',
+      name: 'PhotoUrl__c',
+      parentName: 'MyFirstObject__c',
+      filePath: 'src/field/PhotoUrl__c.field-meta.xml',
+      content: customFieldContent,
+    };
+
+    const result = await reflectCustomFieldSources([unparsed])();
+
+    assertEither(result, (data) => expect(data[0].type.securityClassification).toBe('Internal'));
+  });
+
+  test('the resulting type contains the correct compliance category', async () => {
+    const unparsed: UnparsedCustomFieldBundle = {
+      type: 'customfield',
+      name: 'PhotoUrl__c',
+      parentName: 'MyFirstObject__c',
+      filePath: 'src/field/PhotoUrl__c.field-meta.xml',
+      content: customFieldContent,
+    };
+
+    const result = await reflectCustomFieldSources([unparsed])();
+
+    assertEither(result, (data) => expect(data[0].type.complianceCategory).toBe('PII'));
   });
 
   test('can parse picklist values when there are multiple picklist values available', async () => {

--- a/src/core/reflection/sobject/reflect-custom-field-source.ts
+++ b/src/core/reflection/sobject/reflect-custom-field-source.ts
@@ -18,6 +18,8 @@ export type CustomFieldMetadata = {
   parentName: string;
   pickListValues?: string[];
   required: boolean;
+  securityClassification: string | null;
+  complianceCategory: string | null;
 };
 
 export function reflectCustomFieldSources(
@@ -66,6 +68,8 @@ function toCustomFieldMetadata(parserResult: { CustomField: unknown }): CustomFi
   const defaultValues = {
     description: null,
     required: false,
+    securityClassification: null,
+    complianceCategory: null,
   };
 
   return {

--- a/src/core/reflection/sobject/reflect-custom-object-sources.ts
+++ b/src/core/reflection/sobject/reflect-custom-object-sources.ts
@@ -109,6 +109,8 @@ function convertInlineFieldsToCustomFieldMetadata(
   const label = inlineField.label ? (inlineField.label as string) : name;
   const type = inlineField.type ? (inlineField.type as string) : null;
   const required = inlineField.required ? (inlineField.required as boolean) : false;
+  const securityClassification = inlineField.securityClassification ? (inlineField.securityClassification as string) : null;
+  const complianceCategory = inlineField.complianceCategory ? (inlineField.complianceCategory as string) : null;
 
   return {
     type_name: 'customfield',
@@ -118,6 +120,8 @@ function convertInlineFieldsToCustomFieldMetadata(
     parentName,
     type,
     required,
+    securityClassification,
+    complianceCategory,
     pickListValues: getPickListValues(inlineField),
   };
 }

--- a/src/core/renderables/types.d.ts
+++ b/src/core/renderables/types.d.ts
@@ -202,6 +202,8 @@ export type RenderableCustomField = {
   type: 'field';
   fieldType?: string | null;
   required: boolean;
+  complianceCategory: string | null;
+  securityClassification: string | null;
 };
 
 export type RenderableCustomMetadata = {


### PR DESCRIPTION
We find the need based off of multiple industries ranging from FinRa to FedRamp for the compliance category and security classification to be documented. Adding this to the output generated. Test class updated as well as the markdown example with an additional custom field and .md output. 