### PR TITLE
Update for includeFieldSecurityMetadata option. Should have been Compliance Group.

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ apexdocs changelog --previousVersionDir force-app-previous --currentVersionDir f
 | `--linkingStrategy`        | N/A   | The strategy to use when linking to other classes. Possible values are `relative`, `no-link`, and `none`                                                                                                 | `relative`       | No       |
 | `--customObjectsGroupName` | N/A   | The name under which custom objects will be grouped in the Reference Guide                                                                                                                               | `Custom Objects` | No       |
 | `--triggersGroupName`      | N/A   | The name under which triggers will be grouped in the Reference Guide                                                                                                                                     | `Triggers`       | No       |
+| `--includeFieldSecurityMetadata`      | N/A   | Whether to include the compliance category and security classification for fields in the generated files.                                                                                                                                     | `false`       | No       |
 
 ##### Linking Strategy
 

--- a/examples/markdown/docs/custom-objects/Event__c.md
+++ b/examples/markdown/docs/custom-objects/Event__c.md
@@ -45,7 +45,7 @@ Represents an event that people can register for.
 
 Used to store the U.S. social security number in 9 digit format.
 
-**Compliance Category**
+**Compliance Group**
 PII
 
 **Security Classification**

--- a/examples/markdown/docs/custom-objects/Event__c.md
+++ b/examples/markdown/docs/custom-objects/Event__c.md
@@ -41,6 +41,25 @@ Represents an event that people can register for.
 *Location*
 
 ---
+### Social Security Number
+
+Used to store the U.S. social security number in 9 digit format.
+
+**Compliance Category**
+PII
+
+**Security Classification**
+Internal
+
+**API Name**
+
+`ns__Social_Security_Number__c`
+
+**Type**
+
+*Text*
+
+---
 ### Start Date
 **Required**
 

--- a/examples/markdown/force-app/objects/Event__c/fields/Social_Security_Number__c.field-meta.xml
+++ b/examples/markdown/force-app/objects/Event__c/fields/Social_Security_Number__c.field-meta.xml
@@ -7,6 +7,6 @@
     <length>9</length>
     <trackTrending>false</trackTrending>
     <type>Text</type>
-    <complianceCategory>PII</complianceCategory>
+    <complianceGroup>PII</complianceGroup>
     <securityClassification>Internal</securityClassification>
 </CustomField>

--- a/examples/markdown/force-app/objects/Event__c/fields/Social_Security_Number__c.field-meta.xml
+++ b/examples/markdown/force-app/objects/Event__c/fields/Social_Security_Number__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Social_Security_Number__c</fullName>
+    <externalId>false</externalId>
+    <label>Social Security Number</label>
+    <description>Used to store the U.S. social security number in 9 digit format.</description>
+    <length>9</length>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <complianceCategory>PII</complianceCategory>
+    <securityClassification>Internal</securityClassification>
+</CustomField>

--- a/src/cli/commands/markdown.ts
+++ b/src/cli/commands/markdown.ts
@@ -72,4 +72,9 @@ export const markdownOptions: Record<keyof CliConfigurableMarkdownConfig, Option
     describe: 'The title of the reference guide.',
     default: markdownDefaults.referenceGuideTitle,
   },
+  includeFieldSecurityMetadata: {
+    type: 'boolean',
+    describe: 'Whether to include the compliance category and security classification for fields in the generated files.',
+    default: markdownDefaults.includeFieldSecurityMetadata,
+  }
 };

--- a/src/core/changelog/__test__/helpers/custom-field-metadata-builder.ts
+++ b/src/core/changelog/__test__/helpers/custom-field-metadata-builder.ts
@@ -24,7 +24,7 @@ export default class CustomFieldMetadataBuilder {
       parentName: 'MyObject',
       required: false,
       securityClassification: 'Internal',
-      complianceCategory: 'PII',
+      complianceGroup: 'PII',
     };
   }
 }

--- a/src/core/markdown/__test__/test-helpers.ts
+++ b/src/core/markdown/__test__/test-helpers.ts
@@ -56,6 +56,7 @@ export function generateDocs(bundles: UnparsedSourceBundle[], config?: Partial<M
     linkingStrategy: 'relative',
     excludeTags: [],
     referenceGuideTitle: 'Apex Reference Guide',
+    includeFieldSecurityMetadata: true,
     exclude: [],
     ...config,
   });

--- a/src/core/markdown/adapters/__tests__/interface-adapter.spec.ts
+++ b/src/core/markdown/adapters/__tests__/interface-adapter.spec.ts
@@ -20,6 +20,7 @@ const defaultMarkdownGeneratorConfig: MarkdownGeneratorConfig = {
   sortAlphabetically: false,
   linkingStrategy: 'relative',
   referenceGuideTitle: 'Apex Reference Guide',
+  includeFieldSecurityMetadata: true,
   exclude: [],
   excludeTags: [],
 };

--- a/src/core/markdown/adapters/type-to-renderable.ts
+++ b/src/core/markdown/adapters/type-to-renderable.ts
@@ -357,8 +357,8 @@ function fieldMetadataToRenderable(
     apiName: getApiName(field.name, config),
     fieldType: field.type,
     required: field.required,
-    complianceCategory: renderComplianceCategory(field.complianceCategory, config),
-    securityClassification: renderComplianceCategory(field.securityClassification, config),
+    complianceGroup: renderComplianceGroup(field.complianceGroup, config),
+    securityClassification: renderComplianceGroup(field.securityClassification, config),
     pickListValues: field.pickListValues
       ? {
           headingLevel: headingLevel + 1,
@@ -394,9 +394,9 @@ function getApiName(currentName: string, config: MarkdownGeneratorConfig) {
   return currentName;
 }
 
-function renderComplianceCategory(complianceCategory: string | null, config: MarkdownGeneratorConfig) {
+function renderComplianceGroup(complianceGroup: string | null, config: MarkdownGeneratorConfig) {
   if(config.includeFieldSecurityMetadata) {
-    return complianceCategory;
+    return complianceGroup;
   } else {
     return null;
   }

--- a/src/core/markdown/adapters/type-to-renderable.ts
+++ b/src/core/markdown/adapters/type-to-renderable.ts
@@ -357,6 +357,8 @@ function fieldMetadataToRenderable(
     apiName: getApiName(field.name, config),
     fieldType: field.type,
     required: field.required,
+    complianceCategory: field.complianceCategory,
+    securityClassification: field.securityClassification,
     pickListValues: field.pickListValues
       ? {
           headingLevel: headingLevel + 1,

--- a/src/core/markdown/adapters/type-to-renderable.ts
+++ b/src/core/markdown/adapters/type-to-renderable.ts
@@ -357,8 +357,8 @@ function fieldMetadataToRenderable(
     apiName: getApiName(field.name, config),
     fieldType: field.type,
     required: field.required,
-    complianceCategory: field.complianceCategory,
-    securityClassification: field.securityClassification,
+    complianceCategory: renderComplianceCategory(field.complianceCategory, config),
+    securityClassification: renderComplianceCategory(field.securityClassification, config),
     pickListValues: field.pickListValues
       ? {
           headingLevel: headingLevel + 1,
@@ -392,4 +392,12 @@ function getApiName(currentName: string, config: MarkdownGeneratorConfig) {
     return `${config.namespace}__${currentName}`;
   }
   return currentName;
+}
+
+function renderComplianceCategory(complianceCategory: string | null, config: MarkdownGeneratorConfig) {
+  if(config.includeFieldSecurityMetadata) {
+    return complianceCategory;
+  } else {
+    return null;
+  }
 }

--- a/src/core/markdown/templates/custom-object-template.ts
+++ b/src/core/markdown/templates/custom-object-template.ts
@@ -24,6 +24,16 @@ export const customObjectTemplate = `
 {{{renderContent description}}}
 {{/if}}
 
+{{#if complianceCategory}}
+**Compliance Category**
+{{complianceCategory}}
+{{/if}}
+
+{{#if securityClassification}}
+**Security Classification**
+{{securityClassification}}
+{{/if}}
+
 **API Name**
 
 \`{{{apiName}}}\`

--- a/src/core/markdown/templates/custom-object-template.ts
+++ b/src/core/markdown/templates/custom-object-template.ts
@@ -24,9 +24,9 @@ export const customObjectTemplate = `
 {{{renderContent description}}}
 {{/if}}
 
-{{#if complianceCategory}}
-**Compliance Category**
-{{complianceCategory}}
+{{#if complianceGroup}}
+**Compliance Group**
+{{complianceGroup}}
 {{/if}}
 
 {{#if securityClassification}}

--- a/src/core/reflection/sobject/__test__/reflect-custom-field-sources.spec.ts
+++ b/src/core/reflection/sobject/__test__/reflect-custom-field-sources.spec.ts
@@ -15,7 +15,7 @@ const customFieldContent = `
     <type>Url</type>
     <description>A Photo URL field</description>
     <securityClassification>Internal</securityClassification>
-    <complianceCategory>PII</complianceCategory>
+    <complianceGroup>PII</complianceGroup>
 </CustomField>`;
 
 describe('when parsing custom field metadata', () => {
@@ -123,7 +123,7 @@ describe('when parsing custom field metadata', () => {
     assertEither(result, (data) => expect(data[0].type.securityClassification).toBe('Internal'));
   });
 
-  test('the resulting type contains the correct compliance category', async () => {
+  test('the resulting type contains the correct compliance group', async () => {
     const unparsed: UnparsedCustomFieldBundle = {
       type: 'customfield',
       name: 'PhotoUrl__c',
@@ -134,7 +134,7 @@ describe('when parsing custom field metadata', () => {
 
     const result = await reflectCustomFieldSources([unparsed])();
 
-    assertEither(result, (data) => expect(data[0].type.complianceCategory).toBe('PII'));
+    assertEither(result, (data) => expect(data[0].type.complianceGroup).toBe('PII'));
   });
 
   test('can parse picklist values when there are multiple picklist values available', async () => {

--- a/src/core/reflection/sobject/reflect-custom-field-source.ts
+++ b/src/core/reflection/sobject/reflect-custom-field-source.ts
@@ -19,7 +19,7 @@ export type CustomFieldMetadata = {
   pickListValues?: string[];
   required: boolean;
   securityClassification: string | null;
-  complianceCategory: string | null;
+  complianceGroup: string | null;
 };
 
 export function reflectCustomFieldSources(
@@ -69,7 +69,7 @@ function toCustomFieldMetadata(parserResult: { CustomField: unknown }): CustomFi
     description: null,
     required: false,
     securityClassification: null,
-    complianceCategory: null,
+    complianceGroup: null,
   };
 
   return {

--- a/src/core/reflection/sobject/reflect-custom-object-sources.ts
+++ b/src/core/reflection/sobject/reflect-custom-object-sources.ts
@@ -110,7 +110,7 @@ function convertInlineFieldsToCustomFieldMetadata(
   const type = inlineField.type ? (inlineField.type as string) : null;
   const required = inlineField.required ? (inlineField.required as boolean) : false;
   const securityClassification = inlineField.securityClassification ? (inlineField.securityClassification as string) : null;
-  const complianceCategory = inlineField.complianceCategory ? (inlineField.complianceCategory as string) : null;
+  const complianceGroup = inlineField.complianceGroup ? (inlineField.complianceGroup as string) : null;
 
   return {
     type_name: 'customfield',
@@ -121,7 +121,7 @@ function convertInlineFieldsToCustomFieldMetadata(
     type,
     required,
     securityClassification,
-    complianceCategory,
+    complianceGroup,
     pickListValues: getPickListValues(inlineField),
   };
 }

--- a/src/core/renderables/types.d.ts
+++ b/src/core/renderables/types.d.ts
@@ -202,6 +202,8 @@ export type RenderableCustomField = {
   type: 'field';
   fieldType?: string | null;
   required: boolean;
+  complianceCategory: string | null;
+  securityClassification: string | null;
 };
 
 export type RenderableCustomMetadata = {

--- a/src/core/renderables/types.d.ts
+++ b/src/core/renderables/types.d.ts
@@ -202,7 +202,7 @@ export type RenderableCustomField = {
   type: 'field';
   fieldType?: string | null;
   required: boolean;
-  complianceCategory: string | null;
+  complianceGroup: string | null;
   securityClassification: string | null;
 };
 

--- a/src/core/shared/types.d.ts
+++ b/src/core/shared/types.d.ts
@@ -38,6 +38,7 @@ export type CliConfigurableMarkdownConfig = {
   includeMetadata: boolean;
   linkingStrategy: LinkingStrategy;
   referenceGuideTitle: string;
+  includeFieldSecurityMetadata: boolean;
 };
 
 export type UserDefinedMarkdownConfig = {

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -19,6 +19,7 @@ export const markdownDefaults = {
   linkingStrategy: 'relative' as const,
   referenceGuideTitle: 'Reference Guide',
   excludeTags: [],
+  includeFieldSecurityMetadata: false,
 };
 
 export const openApiDefaults = {


### PR DESCRIPTION
The metadata uses the XML element complianceGroup not complianceCategory. Fixed references to update appropriately when the metadata is pulled down from a Salesforce org. Updated the readme file with the flag information as well.